### PR TITLE
atomic bulk operations by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,7 +609,7 @@ bulk.Setup<Book>()
     .WithSchema("Api") // Specify a schema 
     .WithBulkCopySettings(new BulkCopySettings()
     {
-      BatchSize = 5000,
+      BatchSize = 5000, // Default is 0 - single batch
       BulkCopyTimeout = 720, // Default is 600 seconds
       EnableStreaming = true,
       SqlBulkCopyOptions = SqlBulkCopyOptions.TableLock
@@ -630,6 +630,16 @@ bulk.Setup<Book>()
     .BulkInsert()
     .TmpDisableAllNonClusteredIndexes()
     .Commit(conn);
+
+
+/* When user that run operations on server side does not have permissions to ALTER table or 
+when you wont to fire triggers and check constraint then proper SqlBulkCopyOptions should be applied. */
+
+// Example
+    .WithBulkCopySettings(new BulkCopySettings()
+    {
+      SqlBulkCopyOptions = SqlBulkCopyOptions.FireTriggers | SqlBulkCopyOptions.CheckConstraints
+    })
 
 ```
 

--- a/SqlBulkTools.NetStandard/BulkOperations/BulkCopyOptions.cs
+++ b/SqlBulkTools.NetStandard/BulkOperations/BulkCopyOptions.cs
@@ -8,7 +8,7 @@ namespace SqlBulkTools
     public class BulkCopySettings
     {
         /// <summary>
-        /// Number of seconds for the operation to complete before it times out.
+        /// Number of seconds for the operation to complete before it times out. Default 600.
         /// </summary>
         public int BulkCopyTimeout { get; set; } = 600;
         /// <summary>
@@ -22,9 +22,9 @@ namespace SqlBulkTools
         public SqlBulkCopyOptions SqlBulkCopyOptions { get; set; } = SqlBulkCopyOptions.Default;
 
         /// <summary>
-        /// Number of rows in each batch. At the end of each batch, the rows in the batch are sent to the server.
+        /// Number of rows in each batch. At the end of each batch, the rows in the batch are sent to the server. Default 0 - single batch
         /// </summary>
-        public int BatchSize { get; set; } = 5000;
+        public int BatchSize { get; set; } = 0;
 
         /// <summary>
         /// 

--- a/SqlBulkTools.NetStandard/SqlBulkTools.NetStandard.csproj
+++ b/SqlBulkTools.NetStandard/SqlBulkTools.NetStandard.csproj
@@ -21,4 +21,12 @@
     <PackageTags>SQL BULK BULKINSERT BULKUPDATE</PackageTags>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DocumentationFile>bin\Debug\netstandard2.0\SqlBulkTools.NetStandard.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard2.0\SqlBulkTools.NetStandard.xml</DocumentationFile>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Hi,

Mian reason of this fork is to make bulk operations atomic by default, like it is in origin [SqlBulkCopy](https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlbulkcopy.batchsize?view=netframework-4.7.2#remarks)

With default value of BatchSize set to 5K, when there will be an error during next batch, say in 5001 item then first batch will be inserted. Such behavior should not be default

What you guys think?