### PR TITLE
Take SQL timeout on delete into consideration

### DIFF
--- a/SqlBulkTools.NetStandard/QueryOperations/Delete/DeleteAllRecordsQueryReady.cs
+++ b/SqlBulkTools.NetStandard/QueryOperations/Delete/DeleteAllRecordsQueryReady.cs
@@ -14,6 +14,7 @@ namespace SqlBulkTools
     {
         private readonly string _tableName;
         private readonly string _schema;
+        private readonly int _sqlTimeout;
         private int? _batchQuantity;
 
         /// <summary>
@@ -21,10 +22,11 @@ namespace SqlBulkTools
         /// </summary>
         /// <param name="tableName"></param>
         /// <param name="schema"></param>
-        public DeleteAllRecordsQueryReady(string tableName, string schema)
+        public DeleteAllRecordsQueryReady(string tableName, string schema, int sqlTimeout)
         {
             _tableName = tableName;
             _schema = schema;
+            _sqlTimeout = sqlTimeout;
             _batchQuantity = null;
         }
 
@@ -60,6 +62,7 @@ namespace SqlBulkTools
 
             SqlCommand command = connection.CreateCommand();
             command.Connection = connection;
+            command.CommandTimeout = _sqlTimeout;
 
             command.CommandText = GetQuery(connection);
 
@@ -81,6 +84,7 @@ namespace SqlBulkTools
 
             SqlCommand command = connection.CreateCommand();
             command.Connection = connection;
+            command.CommandTimeout = _sqlTimeout;
 
             command.CommandText = command.CommandText = GetQuery(connection);
 

--- a/SqlBulkTools.NetStandard/QueryOperations/Delete/DeleteQueryCondition.cs
+++ b/SqlBulkTools.NetStandard/QueryOperations/Delete/DeleteQueryCondition.cs
@@ -15,6 +15,7 @@ namespace SqlBulkTools
     {
         private readonly string _tableName;
         private readonly string _schema;
+        private readonly int _sqlTimeout;
         private readonly List<PredicateCondition> _whereConditions;
         private readonly List<SqlParameter> _parameters;
         private int _conditionSortOrder;
@@ -31,6 +32,7 @@ namespace SqlBulkTools
         {
             _tableName = tableName;
             _schema = schema;
+            _sqlTimeout = sqlTimeout;
             _whereConditions = new List<PredicateCondition>();
             _parameters = new List<SqlParameter>();
             _collationColumnDic = new Dictionary<string, string>();
@@ -70,7 +72,7 @@ namespace SqlBulkTools
 
             _conditionSortOrder++;
 
-            return new DeleteQueryReady<T>(_tableName, _schema, _conditionSortOrder, 
+            return new DeleteQueryReady<T>(_tableName, _schema, _sqlTimeout, _conditionSortOrder, 
                 _whereConditions, _parameters, _collationColumnDic, _customColumnMappings);
         }
 
@@ -92,7 +94,7 @@ namespace SqlBulkTools
             string leftName = BulkOperationsHelper.GetExpressionLeftName(expression, PredicateType.Or, "Collation");
             _collationColumnDic.Add(BulkOperationsHelper.GetActualColumn(_customColumnMappings, leftName), collation);
 
-            return new DeleteQueryReady<T>(_tableName, _schema, _conditionSortOrder,
+            return new DeleteQueryReady<T>(_tableName, _schema, _sqlTimeout, _conditionSortOrder,
                 _whereConditions, _parameters, _collationColumnDic, _customColumnMappings);
         }
 
@@ -102,7 +104,7 @@ namespace SqlBulkTools
         /// <returns></returns>
         public DeleteAllRecordsQueryReady<T> AllRecords()
         {
-            return new DeleteAllRecordsQueryReady<T>(_tableName, _schema);
+            return new DeleteAllRecordsQueryReady<T>(_tableName, _schema, _sqlTimeout);
         }
 
     }

--- a/SqlBulkTools.NetStandard/QueryOperations/Delete/DeleteQueryReady.cs
+++ b/SqlBulkTools.NetStandard/QueryOperations/Delete/DeleteQueryReady.cs
@@ -18,6 +18,7 @@ namespace SqlBulkTools
     {
         private readonly string _tableName;
         private readonly string _schema;
+        private readonly int _sqlTimeout;
         private readonly List<PredicateCondition> _whereConditions;
         private readonly List<PredicateCondition> _andConditions;
         private readonly List<PredicateCondition> _orConditions;
@@ -32,16 +33,18 @@ namespace SqlBulkTools
         /// </summary>
         /// <param name="tableName"></param>
         /// <param name="schema"></param>
+        /// <param name="sqlTimeout"></param>
         /// <param name="conditionSortOrder"></param>
         /// <param name="whereConditions"></param>
         /// <param name="parameters"></param>
         /// <param name="collationColumnDic"></param>
         /// <param name="customColumnMappings"></param>
-        public DeleteQueryReady(string tableName, string schema, int conditionSortOrder, List<PredicateCondition> whereConditions,
+        public DeleteQueryReady(string tableName, string schema, int sqlTimeout, int conditionSortOrder, List<PredicateCondition> whereConditions,
             List<SqlParameter> parameters, Dictionary<string, string> collationColumnDic, Dictionary<string, string> customColumnMappings)
         {
             _tableName = tableName;
             _schema = schema;
+            _sqlTimeout = sqlTimeout;
             _whereConditions = whereConditions;
             _andConditions = new List<PredicateCondition>();
             _orConditions = new List<PredicateCondition>();
@@ -148,6 +151,7 @@ namespace SqlBulkTools
 
             SqlCommand command = connection.CreateCommand();
             command.Connection = connection;
+            command.CommandTimeout = _sqlTimeout;
 
             command.CommandText = GetQuery(connection);
 
@@ -174,6 +178,7 @@ namespace SqlBulkTools
 
             SqlCommand command = connection.CreateCommand();
             command.Connection = connection;
+            command.CommandTimeout = _sqlTimeout;
 
             command.CommandText = command.CommandText = GetQuery(connection);
 


### PR DESCRIPTION
Currently the value passed into WithSqlCommandTimeout for DeleteQuery is ignored and not used as CommandTimeout. This pull request solves that