### PR TITLE
Make API F# friendly and bug fix

### DIFF
--- a/SqlBulkTools.FSharp/Builders.fs
+++ b/SqlBulkTools.FSharp/Builders.fs
@@ -1,0 +1,214 @@
+﻿module SqlBulkTools.FSharp
+
+open System.Data
+open SqlBulkTools
+open SqlBulkTools.BulkCopy
+
+type Operation<'T> = 
+    | OpNone
+    | OpSetup of Setup
+    | OpForCollection of BulkForCollection<'T>
+    | OpWithTable of BulkTable<'T>
+    | OpAddColumn of BulkAddColumn<'T>
+    | OpUpdate of BulkUpdate<'T>
+    | OpUpsert of BulkInsertOrUpdate<'T>
+    | OpDelete of BulkDelete<'T>
+
+type BulkInsertBuilder(conn: IDbConnection) = 
+    let def = OpNone
+
+    member this.For (rows: seq<'T>, f: 'T -> Operation<'T>) =
+        OpForCollection (BulkOperations().Setup().ForCollection(rows))
+
+    member this.Yield _ = 
+        def
+
+    [<CustomOperation("table", MaintainsVariableSpace = true)>]
+    member this.Table (props, tbl) = 
+        match props with
+        | OpForCollection bulk -> OpWithTable(bulk.WithTable tbl)
+        | _ -> failwith "Must add collection first."
+
+    [<CustomOperation("column", MaintainsVariableSpace=true)>]
+    member this.Column (props, [<ProjectionParameter>] colExpr) =
+        match props with
+        | OpWithTable bulk -> OpAddColumn (bulk.AddColumn(colExpr))
+        | OpAddColumn bulk -> OpAddColumn (bulk.AddColumn(colExpr))
+        | _ -> failwith "Must add table first."
+
+    [<CustomOperation("columnDest", MaintainsVariableSpace=true)>]
+    member this.ColumnDestination (props, [<ProjectionParameter>] colExpr, destination: string) =
+        match props with
+        | OpWithTable bulk -> OpAddColumn (bulk.AddColumn(colExpr, destination))
+        | OpAddColumn bulk -> OpAddColumn (bulk.AddColumn(colExpr, destination))
+        | _ -> failwith "Must add table first."
+
+    member this.Run (props) =
+        match props with
+        | OpAddColumn bulk -> bulk.BulkInsert().Commit(conn)
+        | _ -> failwith "Must add at least one column first."
+
+/// A bulk insert will attempt to insert all records. If you have any unique constraints on columns, these must be respected. 
+/// Notes: (1) Only the columns configured (via AddColumn) will be evaluated.
+let bulkInsert conn = BulkInsertBuilder(conn)
+
+
+type BulkUpdateBuilder(conn: IDbConnection) = 
+    let def = OpNone
+
+    member this.For (rows: seq<'T>, f: 'T -> Operation<'T>) =
+        OpForCollection (BulkOperations().Setup().ForCollection(rows))
+
+    member this.Yield _ = 
+        def
+
+    [<CustomOperation("table", MaintainsVariableSpace = true)>]
+    member this.Table (props, tbl) = 
+        match props with
+        | OpForCollection bulk -> OpWithTable(bulk.WithTable tbl)
+        | _ -> failwith "Must add collection first."
+
+    [<CustomOperation("column", MaintainsVariableSpace=true)>]
+    member this.Column (props, [<ProjectionParameter>] colExpr) =
+        match props with
+        | OpWithTable bulk -> OpAddColumn (bulk.AddColumn(colExpr))
+        | OpAddColumn bulk -> OpAddColumn (bulk.AddColumn(colExpr))
+        | _ -> failwith "Must add table first."
+
+    [<CustomOperation("columnDest", MaintainsVariableSpace=true)>]
+    member this.ColumnDestination (props, [<ProjectionParameter>] colExpr, destination: string) =
+        match props with
+        | OpWithTable bulk -> OpAddColumn (bulk.AddColumn(colExpr, destination))
+        | OpAddColumn bulk -> OpAddColumn (bulk.AddColumn(colExpr, destination))
+        | _ -> failwith "Must add table first."
+
+    [<CustomOperation("matchTargetOn", MaintainsVariableSpace=true)>]
+    member this.MatchTargetOn (props, [<ProjectionParameter>] colExpr) =
+        match props with
+        | OpAddColumn bulk -> OpUpdate (bulk.BulkUpdate().MatchTargetOn(colExpr))
+        | OpUpdate bulk -> OpUpdate (bulk.MatchTargetOn(colExpr))
+        | _ -> failwith "Must add columns first."
+
+    [<CustomOperation("updateWhen", MaintainsVariableSpace=true)>]
+    member this.UpdateWhen (props, [<ProjectionParameter>] filter) =
+        match props with
+        | OpAddColumn bulk -> OpUpdate (bulk.BulkUpdate().UpdateWhen(filter))
+        | OpUpdate bulk -> OpUpdate (bulk.UpdateWhen(filter))
+        | _ -> failwith "Must add columns first."
+
+    member this.Run (props) =
+        match props with
+        | OpUpdate bulk -> bulk.Commit(conn)
+        | _ -> failwith "Must add at least one column first."
+
+/// A bulk update will attempt to update any matching records. Notes: (1) BulkUpdate requires at least one MatchTargetOn 
+/// property to be configured. (2) Only the columns configured (via AddColumn) will be evaluated.
+let bulkUpdate conn = BulkUpdateBuilder(conn)
+
+
+type BulkUpsertBuilder(conn: IDbConnection) = 
+    let def = OpNone
+
+    member this.For (rows: seq<'T>, f: 'T -> Operation<'T>) =
+        OpForCollection (BulkOperations().Setup().ForCollection(rows))
+
+    member this.Yield _ = 
+        def
+
+    [<CustomOperation("table", MaintainsVariableSpace = true)>]
+    member this.Table (props, tbl) = 
+        match props with
+        | OpForCollection bulk -> OpWithTable(bulk.WithTable tbl)
+        | _ -> failwith "Must add collection first."
+
+    [<CustomOperation("column", MaintainsVariableSpace=true)>]
+    member this.Column (props, [<ProjectionParameter>] colExpr) =
+        match props with
+        | OpWithTable bulk -> OpAddColumn (bulk.AddColumn(colExpr))
+        | OpAddColumn bulk -> OpAddColumn (bulk.AddColumn(colExpr))
+        | _ -> failwith "Must add table first."
+
+    [<CustomOperation("columnDest", MaintainsVariableSpace=true)>]
+    member this.ColumnDestination (props, [<ProjectionParameter>] colExpr, destination: string) =
+        match props with
+        | OpWithTable bulk -> OpAddColumn (bulk.AddColumn(colExpr, destination))
+        | OpAddColumn bulk -> OpAddColumn (bulk.AddColumn(colExpr, destination))
+        | _ -> failwith "Must add table first."
+
+    [<CustomOperation("matchTargetOn", MaintainsVariableSpace=true)>]
+    member this.MatchTargetOn (props, [<ProjectionParameter>] colExpr) =
+        match props with
+        | OpAddColumn bulk -> OpUpsert (bulk.BulkInsertOrUpdate().MatchTargetOn(colExpr))
+        | OpUpsert bulk -> OpUpsert (bulk.MatchTargetOn(colExpr))
+        | _ -> failwith "Must add columns first."
+
+    [<CustomOperation("updateWhen", MaintainsVariableSpace=true)>]
+    member this.UpdateWhen (props, [<ProjectionParameter>] filter) =
+        match props with
+        | OpAddColumn bulk -> OpUpsert (bulk.BulkInsertOrUpdate().UpdateWhen(filter))
+        | OpUpsert bulk -> OpUpsert (bulk.UpdateWhen(filter))
+        | _ -> failwith "Must add columns first."
+
+    member this.Run (props) =
+        match props with
+        | OpUpsert bulk -> bulk.Commit(conn)
+        | _ -> failwith "Must add at least one column first."
+
+/// A bulk insert or update is also known as bulk upsert or merge. All matching rows from the source will be updated.
+/// Any unique rows not found in target but exist in source will be added. Notes: (1) BulkInsertOrUpdate requires at least 
+/// one MatchTargetOn property to be configured. (2) Only the columns configured (via AddColumn) 
+/// will be evaluated.
+let bulkUpsert conn = BulkUpsertBuilder(conn)
+
+
+type BulkDeleteBuilder(conn: IDbConnection) = 
+    let def = OpNone
+
+    member this.For (rows: seq<'T>, f: 'T -> Operation<'T>) =
+        OpForCollection (BulkOperations().Setup().ForCollection(rows))
+
+    member this.Yield _ = 
+        def
+
+    [<CustomOperation("table", MaintainsVariableSpace = true)>]
+    member this.Table (props, tbl) = 
+        match props with
+        | OpForCollection bulk -> OpWithTable(bulk.WithTable tbl)
+        | _ -> failwith "Must add collection first."
+
+    [<CustomOperation("column", MaintainsVariableSpace=true)>]
+    member this.Column (props, [<ProjectionParameter>] colExpr) =
+        match props with
+        | OpWithTable bulk -> OpAddColumn (bulk.AddColumn(colExpr))
+        | OpAddColumn bulk -> OpAddColumn (bulk.AddColumn(colExpr))
+        | _ -> failwith "Must add table first."
+
+    [<CustomOperation("columnDest", MaintainsVariableSpace=true)>]
+    member this.ColumnDestination (props, [<ProjectionParameter>] colExpr, destination: string) =
+        match props with
+        | OpWithTable bulk -> OpAddColumn (bulk.AddColumn(colExpr, destination))
+        | OpAddColumn bulk -> OpAddColumn (bulk.AddColumn(colExpr, destination))
+        | _ -> failwith "Must add table first."
+
+    [<CustomOperation("matchTargetOn", MaintainsVariableSpace=true)>]
+    member this.MatchTargetOn (props, [<ProjectionParameter>] colExpr) =
+        match props with
+        | OpAddColumn bulk -> OpDelete (bulk.BulkDelete().MatchTargetOn(colExpr))
+        | OpDelete bulk -> OpDelete (bulk.MatchTargetOn(colExpr))
+        | _ -> failwith "Must add columns first."
+
+    [<CustomOperation("deleteWhen", MaintainsVariableSpace=true)>]
+    member this.UpdateWhen (props, [<ProjectionParameter>] filter) =
+        match props with
+        | OpAddColumn bulk -> OpDelete (bulk.BulkDelete().DeleteWhen(filter))
+        | OpDelete bulk -> OpDelete (bulk.DeleteWhen(filter))
+        | _ -> failwith "Must add columns first."
+
+    member this.Run (props) =
+        match props with
+        | OpDelete bulk -> bulk.Commit(conn)
+        | _ -> failwith "Must add at least one column first."
+
+/// A bulk delete will delete records when matched. Consider using a DTO with only the needed information (e.g. PK) Notes: 
+/// (1) BulkUpdate requires at least one MatchTargetOn property to be configured.
+let bulkDelete conn = BulkDeleteBuilder(conn)

--- a/SqlBulkTools.FSharp/SqlBulkTools.FSharp.fsproj
+++ b/SqlBulkTools.FSharp/SqlBulkTools.FSharp.fsproj
@@ -9,7 +9,7 @@
     <PackageProjectUrl>https://github.com/JordanMarr/SqlBulkTools.FSharp</PackageProjectUrl>
     <RepositoryUrl>https://github.com/JordanMarr/SqlBulkTools.FSharp</RepositoryUrl>
     <PackageTags>sql bulk bulkinsert bulkupdate upsert fsharp</PackageTags>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,7 +17,29 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\SqlBulkTools.NetStandard\SqlBulkTools.NetStandard.csproj" />
+      <ProjectReference Include="..\SqlBulkTools.NetStandard\SqlBulkTools.NetStandard.csproj">
+          <PrivateAssets>all</PrivateAssets>
+      </ProjectReference>
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="4.7.2" />
+  </ItemGroup>
+
+  <!--
+    The following solves the problem that 'dotnet pack' does not include the DLLs from referenced projects.
+    See https://github.com/NuGet/Home/issues/3891 for a description of the problem
+    and for newer versions / workarounds / built-in methods.
+  -->
+  <PropertyGroup>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
+    <!-- include PDBs in the NuGet package -->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  </PropertyGroup>
+  <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences">
+    <ItemGroup>
+      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')-&gt;WithMetadataValue('PrivateAssets', 'all'))" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/SqlBulkTools.FSharp/SqlBulkTools.FSharp.fsproj
+++ b/SqlBulkTools.FSharp/SqlBulkTools.FSharp.fsproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageId>SqlBulkTools.FSharp</PackageId>
+    <Authors>tiagorosendo, zek99, gtaylor44, JordanMarr</Authors>
+    <Company />
+    <PackageProjectUrl>https://github.com/JordanMarr/SqlBulkTools.FSharp</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/JordanMarr/SqlBulkTools.FSharp</RepositoryUrl>
+    <PackageTags>sql bulk bulkinsert bulkupdate upsert fsharp</PackageTags>
+    <Version>0.1.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Builders.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SqlBulkTools.NetStandard\SqlBulkTools.NetStandard.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SqlBulkTools.NetStandard/BulkOperations/AbstractOperation.cs
+++ b/SqlBulkTools.NetStandard/BulkOperations/AbstractOperation.cs
@@ -74,7 +74,7 @@ namespace SqlBulkTools
         /// <param name="columnName"></param>
         /// <exception cref="SqlBulkToolsException"></exception>
 
-        protected void SetIdentity(Expression<Func<T, object>> columnName)
+        protected void SetIdentity<TProp>(Expression<Func<T, TProp>> columnName)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
 
@@ -106,7 +106,7 @@ namespace SqlBulkTools
         /// </summary>
         /// <param name="columnName"></param>
         /// <param name="outputIdentity"></param>
-        protected void SetIdentity(Expression<Func<T, object>> columnName, ColumnDirectionType outputIdentity)
+        protected void SetIdentity<TProp>(Expression<Func<T, TProp>> columnName, ColumnDirectionType outputIdentity)
         {
             _outputIdentity = outputIdentity;
             SetIdentity(columnName);

--- a/SqlBulkTools.NetStandard/BulkOperations/BulkAddColumn.cs
+++ b/SqlBulkTools.NetStandard/BulkOperations/BulkAddColumn.cs
@@ -33,14 +33,14 @@ namespace SqlBulkTools
         /// </summary>
         /// <param name="columnName">Column name as represented in database</param>
         /// <returns></returns>
-        public BulkAddColumn<T> AddColumn(Expression<Func<T, object>> columnName)
+        public BulkAddColumn<T> AddColumn<TProp>(Expression<Func<T, TProp>> columnName)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
             _columns.Add(propertyName);
             return this;
         }
 
-        public BulkAddColumn<T> AddColumns(params Expression<Func<T, object>>[] columnNames)
+        public BulkAddColumn<T> AddColumns<TProp>(params Expression<Func<T, TProp>>[] columnNames)
         {
             foreach (var column in columnNames)
                 AddColumn(column);
@@ -56,7 +56,7 @@ namespace SqlBulkTools
         /// If any of your model property names do not match 
         /// the SQL table column(s) as defined in given table, then use this overload to set up a custom mapping. </param>
         /// <returns></returns>
-        public BulkAddColumn<T> AddColumn(Expression<Func<T, object>> columnName, string destination)
+        public BulkAddColumn<T> AddColumn<TProp>(Expression<Func<T, TProp>> columnName, string destination)
         {
             if (destination == null)
                 throw new ArgumentNullException(nameof(destination));

--- a/SqlBulkTools.NetStandard/BulkOperations/BulkAddColumnList.cs
+++ b/SqlBulkTools.NetStandard/BulkOperations/BulkAddColumnList.cs
@@ -41,7 +41,7 @@ namespace SqlBulkTools
         /// The actual name of column as represented in SQL table. 
         /// </param>
         /// <returns></returns>
-        public BulkAddColumnList<T> CustomColumnMapping(Expression<Func<T, object>> source, string destination)
+        public BulkAddColumnList<T> CustomColumnMapping<TProp>(Expression<Func<T, TProp>> source, string destination)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(source);
             _customColumnMappings.Add(propertyName, destination);
@@ -54,7 +54,7 @@ namespace SqlBulkTools
         /// <param name="columnName"></param>
         /// <returns></returns>
         /// <exception cref="SqlBulkToolsException"></exception>
-        public BulkAddColumnList<T> RemoveColumn(Expression<Func<T, object>> columnName)
+        public BulkAddColumnList<T> RemoveColumn<TProp>(Expression<Func<T, TProp>> columnName)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
             if (_columns.Contains(propertyName))

--- a/SqlBulkTools.NetStandard/BulkOperations/BulkDelete.cs
+++ b/SqlBulkTools.NetStandard/BulkOperations/BulkDelete.cs
@@ -47,7 +47,7 @@ namespace SqlBulkTools
         /// </summary>
         /// <param name="columnName"></param>
         /// <returns></returns>
-        public BulkDelete<T> MatchTargetOn(Expression<Func<T, object>> columnName)
+        public BulkDelete<T> MatchTargetOn<TProp>(Expression<Func<T, TProp>> columnName)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
 
@@ -67,7 +67,7 @@ namespace SqlBulkTools
         /// <param name="columnName"></param>
         /// <param name="collation">Only explicitly set the collation if there is a collation conflict.</param>
         /// <returns></returns>
-        public BulkDelete<T> MatchTargetOn(Expression<Func<T, object>> columnName, string collation)
+        public BulkDelete<T> MatchTargetOn<TProp>(Expression<Func<T, TProp>> columnName, string collation)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
 
@@ -111,7 +111,7 @@ namespace SqlBulkTools
         /// </summary>
         /// <param name="columnName"></param>
         /// <returns></returns>
-        public BulkDelete<T> SetIdentityColumn(Expression<Func<T, object>> columnName)
+        public BulkDelete<T> SetIdentityColumn<TProp>(Expression<Func<T, TProp>> columnName)
         {
             base.SetIdentity(columnName);
             return this;
@@ -124,7 +124,7 @@ namespace SqlBulkTools
         /// <param name="columnName"></param>
         /// <param name="outputIdentity"></param>
         /// <returns></returns>
-        public BulkDelete<T> SetIdentityColumn(Expression<Func<T, object>> columnName, ColumnDirectionType outputIdentity)
+        public BulkDelete<T> SetIdentityColumn<TProp>(Expression<Func<T, TProp>> columnName, ColumnDirectionType outputIdentity)
         {
             base.SetIdentity(columnName, outputIdentity);
             return this;

--- a/SqlBulkTools.NetStandard/BulkOperations/BulkInsert.cs
+++ b/SqlBulkTools.NetStandard/BulkOperations/BulkInsert.cs
@@ -39,7 +39,7 @@ namespace SqlBulkTools
         /// </summary>
         /// <param name="columnName"></param>
         /// <returns></returns>
-        public BulkInsert<T> SetIdentityColumn(Expression<Func<T, object>> columnName)
+        public BulkInsert<T> SetIdentityColumn<TProp>(Expression<Func<T, TProp>> columnName)
         {
             base.SetIdentity(columnName);
             return this;
@@ -52,7 +52,7 @@ namespace SqlBulkTools
         /// <param name="columnName"></param>
         /// <param name="outputIdentity"></param>
         /// <returns></returns>
-        public BulkInsert<T> SetIdentityColumn(Expression<Func<T, object>> columnName, ColumnDirectionType outputIdentity)
+        public BulkInsert<T> SetIdentityColumn<TProp>(Expression<Func<T, TProp>> columnName, ColumnDirectionType outputIdentity)
         {
             base.SetIdentity(columnName, outputIdentity);
             return this;

--- a/SqlBulkTools.NetStandard/BulkOperations/BulkInsertOrUpdate.cs
+++ b/SqlBulkTools.NetStandard/BulkOperations/BulkInsertOrUpdate.cs
@@ -52,7 +52,7 @@ namespace SqlBulkTools
         /// </summary>
         /// <param name="columnName"></param>
         /// <returns></returns>
-        public BulkInsertOrUpdate<T> MatchTargetOn(Expression<Func<T, object>> columnName)
+        public BulkInsertOrUpdate<T> MatchTargetOn<TProp>(Expression<Func<T, TProp>> columnName)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
 
@@ -72,7 +72,7 @@ namespace SqlBulkTools
         /// <param name="columnName"></param>
         /// <param name="collation">Only explicitly set the collation if there is a collation conflict.</param>
         /// <returns></returns>
-        public BulkInsertOrUpdate<T> MatchTargetOn(Expression<Func<T, object>> columnName, string collation)
+        public BulkInsertOrUpdate<T> MatchTargetOn<TProp>(Expression<Func<T, TProp>> columnName, string collation)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
 
@@ -91,7 +91,7 @@ namespace SqlBulkTools
         /// </summary>
         /// <param name="columnName"></param>
         /// <returns></returns>
-        public BulkInsertOrUpdate<T> SetIdentityColumn(Expression<Func<T, object>> columnName)
+        public BulkInsertOrUpdate<T> SetIdentityColumn<TProp>(Expression<Func<T, TProp>> columnName)
         {
             SetIdentity(columnName);
             return this;
@@ -104,7 +104,7 @@ namespace SqlBulkTools
         /// <param name="columnName"></param>
         /// <param name="outputIdentity"></param>
         /// <returns></returns>
-        public BulkInsertOrUpdate<T> SetIdentityColumn(Expression<Func<T, object>> columnName, ColumnDirectionType outputIdentity)
+        public BulkInsertOrUpdate<T> SetIdentityColumn<TProp>(Expression<Func<T, TProp>> columnName, ColumnDirectionType outputIdentity)
         {
             base.SetIdentity(columnName, outputIdentity);
             return this;
@@ -115,7 +115,7 @@ namespace SqlBulkTools
         /// </summary>
         /// <param name="columnName"></param>
         /// <returns></returns>
-        public BulkInsertOrUpdate<T> ExcludeColumnFromUpdate(Expression<Func<T, object>> columnName)
+        public BulkInsertOrUpdate<T> ExcludeColumnFromUpdate<TProp>(Expression<Func<T, TProp>> columnName)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
 

--- a/SqlBulkTools.NetStandard/BulkOperations/BulkTable.cs
+++ b/SqlBulkTools.NetStandard/BulkOperations/BulkTable.cs
@@ -47,14 +47,14 @@ namespace SqlBulkTools.BulkCopy
         /// </summary>
         /// <param name="columnName">Column name as represented in database</param>
         /// <returns></returns>
-        public BulkAddColumn<T> AddColumn(Expression<Func<T, object>> columnName)
+        public BulkAddColumn<T> AddColumn<TProp>(Expression<Func<T, TProp>> columnName)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
             Columns.Add(propertyName);
             return new BulkAddColumn<T>(bulk, _list, _tableName, Columns, CustomColumnMappings, _schema, _bulkCopySettings, _propertyInfoList);
         }
 
-        public BulkAddColumn<T> AddColumns(params Expression<Func<T, object>>[] columnNames)
+        public BulkAddColumn<T> AddColumns<TProp>(params Expression<Func<T, TProp>>[] columnNames)
         {
             foreach (var column in columnNames)
             {
@@ -73,7 +73,7 @@ namespace SqlBulkTools.BulkCopy
         /// If any of your model property names do not match 
         /// the SQL table column(s) as defined in given table, then use this overload to set up a custom mapping. </param>
         /// <returns></returns>
-        public BulkAddColumn<T> AddColumn(Expression<Func<T, object>> columnName, string destination)
+        public BulkAddColumn<T> AddColumn<TProp>(Expression<Func<T, TProp>> columnName, string destination)
         {
             if (destination == null)
                 throw new ArgumentNullException(nameof(destination));

--- a/SqlBulkTools.NetStandard/BulkOperations/BulkUpdate.cs
+++ b/SqlBulkTools.NetStandard/BulkOperations/BulkUpdate.cs
@@ -62,7 +62,7 @@ namespace SqlBulkTools
         /// </summary>
         /// <param name="columnName"></param>
         /// <returns></returns>
-        public BulkUpdate<T> MatchTargetOn(Expression<Func<T, object>> columnName)
+        public BulkUpdate<T> MatchTargetOn<TProp>(Expression<Func<T, TProp>> columnName)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
 
@@ -82,7 +82,7 @@ namespace SqlBulkTools
         /// <param name="columnName"></param>
         /// <param name="collation">Only explicitly set the collation if there is a collation conflict.</param>
         /// <returns></returns>
-        public BulkUpdate<T> MatchTargetOn(Expression<Func<T, object>> columnName, string collation)
+        public BulkUpdate<T> MatchTargetOn<TProp>(Expression<Func<T, TProp>> columnName, string collation)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
 
@@ -101,7 +101,7 @@ namespace SqlBulkTools
         /// </summary>
         /// <param name="columnName"></param>
         /// <returns></returns>
-        public BulkUpdate<T> SetIdentityColumn(Expression<Func<T, object>> columnName)
+        public BulkUpdate<T> SetIdentityColumn<TProp>(Expression<Func<T, TProp>> columnName)
         {
             base.SetIdentity(columnName);
             return this;
@@ -114,7 +114,7 @@ namespace SqlBulkTools
         /// <param name="columnName"></param>
         /// <param name="outputIdentity"></param>
         /// <returns></returns>
-        public BulkUpdate<T> SetIdentityColumn(Expression<Func<T, object>> columnName, ColumnDirectionType outputIdentity)
+        public BulkUpdate<T> SetIdentityColumn<TProp>(Expression<Func<T, TProp>> columnName, ColumnDirectionType outputIdentity)
         {
             base.SetIdentity(columnName, outputIdentity);
             return this;

--- a/SqlBulkTools.NetStandard/DataTableOperations/DataTableAllColumnSelect.cs
+++ b/SqlBulkTools.NetStandard/DataTableOperations/DataTableAllColumnSelect.cs
@@ -37,7 +37,7 @@ namespace SqlBulkTools
         /// you can add a custom column mapping.   
         /// </summary>
         /// <returns></returns>
-        public DataTableAllColumnSelect<T> CustomColumnMapping(Expression<Func<T, object>> source, string destination)
+        public DataTableAllColumnSelect<T> CustomColumnMapping<TProp>(Expression<Func<T, TProp>> source, string destination)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(source);
             CustomColumnMappings.Add(propertyName, destination);
@@ -50,7 +50,7 @@ namespace SqlBulkTools
         /// <param name="columnName"></param>
         /// <returns></returns>
         /// <exception cref="SqlBulkToolsException"></exception>
-        public DataTableAllColumnSelect<T> RemoveColumn(Expression<Func<T, object>> columnName)
+        public DataTableAllColumnSelect<T> RemoveColumn<TProp>(Expression<Func<T, TProp>> columnName)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
             if (_columns.Contains(propertyName))

--- a/SqlBulkTools.NetStandard/DataTableOperations/DataTableColumns.cs
+++ b/SqlBulkTools.NetStandard/DataTableOperations/DataTableColumns.cs
@@ -35,7 +35,7 @@ namespace SqlBulkTools
         /// </summary>
         /// <param name="columnName"></param>
         /// <returns></returns>
-        public DataTableSingularColumnSelect<T> AddColumn(Expression<Func<T, object>> columnName)
+        public DataTableSingularColumnSelect<T> AddColumn<TProp>(Expression<Func<T, TProp>> columnName)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
             Columns.Add(propertyName);

--- a/SqlBulkTools.NetStandard/DataTableOperations/DataTableSingularColumnSelect.cs
+++ b/SqlBulkTools.NetStandard/DataTableOperations/DataTableSingularColumnSelect.cs
@@ -36,7 +36,7 @@ namespace SqlBulkTools
         /// </summary>
         /// <param name="columnName">Column name as represented in database</param>
         /// <returns></returns>
-        public DataTableSingularColumnSelect<T> AddColumn(Expression<Func<T, object>> columnName)
+        public DataTableSingularColumnSelect<T> AddColumn<TProp>(Expression<Func<T, TProp>> columnName)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
             _columns.Add(propertyName);
@@ -48,7 +48,7 @@ namespace SqlBulkTools
         /// you can add a custom column mapping. 
         /// </summary>
         /// <returns></returns>
-        public DataTableSingularColumnSelect<T> CustomColumnMapping(Expression<Func<T, object>> source, string destination)
+        public DataTableSingularColumnSelect<T> CustomColumnMapping<TProp>(Expression<Func<T, TProp>> source, string destination)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(source);
             CustomColumnMappings.Add(propertyName, destination);

--- a/SqlBulkTools.NetStandard/Helper/BulkOperationsHelper.cs
+++ b/SqlBulkTools.NetStandard/Helper/BulkOperationsHelper.cs
@@ -65,7 +65,7 @@ namespace SqlBulkTools
         internal static string BuildCreateTempTable(HashSet<string> columns, DataTable schema,
             ColumnDirectionType outputIdentity)
         {
-            var actualColumns = new Dictionary<string, string>();
+            var actualColumns = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             var actualColumnsMaxCharLength = new Dictionary<string, string>();
             var actualColumnsNumericPrecision = new Dictionary<string, PrecisionType>();
             var actualColumnsDateTimePrecision = new Dictionary<string, string>();

--- a/SqlBulkTools.NetStandard/QueryOperations/Delete/DeleteQueryCondition.cs
+++ b/SqlBulkTools.NetStandard/QueryOperations/Delete/DeleteQueryCondition.cs
@@ -50,7 +50,7 @@ namespace SqlBulkTools
         /// The actual name of column as represented in SQL table. 
         /// </param>
         /// <returns></returns>
-        public DeleteQueryCondition<T> CustomColumnMapping(Expression<Func<T, object>> source, string destination)
+        public DeleteQueryCondition<T> CustomColumnMapping<TProp>(Expression<Func<T, TProp>> source, string destination)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(source);
             _customColumnMappings.Add(propertyName, destination);

--- a/SqlBulkTools.NetStandard/QueryOperations/QueryAddColumn.cs
+++ b/SqlBulkTools.NetStandard/QueryOperations/QueryAddColumn.cs
@@ -46,7 +46,7 @@ namespace SqlBulkTools.QueryOperations
         /// </summary>
         /// <param name="columnName">Column name as represented in database</param>
         /// <returns></returns>
-        public QueryAddColumn<T> AddColumn(Expression<Func<T, object>> columnName)
+        public QueryAddColumn<T> AddColumn<TProp>(Expression<Func<T, TProp>> columnName)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
             _columns.Add(propertyName);
@@ -62,7 +62,7 @@ namespace SqlBulkTools.QueryOperations
         /// If any of your model property names do not match 
         /// the SQL table column(s) as defined in given table, then use this overload to set up a custom mapping. </param>
         /// <returns></returns>
-        public QueryAddColumn<T> AddColumn(Expression<Func<T, object>> columnName, string destination)
+        public QueryAddColumn<T> AddColumn<TProp>(Expression<Func<T, TProp>> columnName, string destination)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
             _columns.Add(propertyName);

--- a/SqlBulkTools.NetStandard/QueryOperations/QueryAddColumnList.cs
+++ b/SqlBulkTools.NetStandard/QueryOperations/QueryAddColumnList.cs
@@ -78,7 +78,7 @@ namespace SqlBulkTools.QueryOperations
         /// <param name="columnName"></param>
         /// <returns></returns>
         /// <exception cref="SqlBulkToolsException"></exception>
-        public QueryAddColumnList<T> RemoveColumn(Expression<Func<T, object>> columnName)
+        public QueryAddColumnList<T> RemoveColumn<TProp>(Expression<Func<T, TProp>> columnName)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
             if (_columns.Contains(propertyName))
@@ -104,7 +104,7 @@ namespace SqlBulkTools.QueryOperations
         /// The actual name of column as represented in SQL table. 
         /// </param>
         /// <returns></returns>
-        public QueryAddColumnList<T> CustomColumnMapping(Expression<Func<T, object>> source, string destination)
+        public QueryAddColumnList<T> CustomColumnMapping<TProp>(Expression<Func<T, TProp>> source, string destination)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(source);
             CustomColumnMappings.Add(propertyName, destination);

--- a/SqlBulkTools.NetStandard/QueryOperations/QueryInsertReady.cs
+++ b/SqlBulkTools.NetStandard/QueryOperations/QueryInsertReady.cs
@@ -54,7 +54,7 @@ namespace SqlBulkTools.QueryOperations
         /// </summary>
         /// <param name="columnName"></param>
         /// <returns></returns>
-        public QueryInsertReady<T> SetIdentityColumn(Expression<Func<T, object>> columnName)
+        public QueryInsertReady<T> SetIdentityColumn<TProp>(Expression<Func<T, TProp>> columnName)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
 
@@ -77,7 +77,7 @@ namespace SqlBulkTools.QueryOperations
         /// <param name="columnName"></param>
         /// <param name="direction"></param>
         /// <returns></returns>
-        public QueryInsertReady<T> SetIdentityColumn(Expression<Func<T, object>> columnName, ColumnDirectionType direction)
+        public QueryInsertReady<T> SetIdentityColumn<TProp>(Expression<Func<T, TProp>> columnName, ColumnDirectionType direction)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
             _outputIdentity = direction;

--- a/SqlBulkTools.NetStandard/QueryOperations/QueryTable.cs
+++ b/SqlBulkTools.NetStandard/QueryOperations/QueryTable.cs
@@ -46,7 +46,7 @@ namespace SqlBulkTools.QueryOperations
         /// </summary>
         /// <param name="columnName">Column name as represented in database</param>
         /// <returns></returns>
-        public QueryAddColumn<T> AddColumn(Expression<Func<T, object>> columnName)
+        public QueryAddColumn<T> AddColumn<TProp>(Expression<Func<T, TProp>> columnName)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
             Columns.Add(propertyName);

--- a/SqlBulkTools.NetStandard/QueryOperations/QueryUpdateReady.cs
+++ b/SqlBulkTools.NetStandard/QueryOperations/QueryUpdateReady.cs
@@ -69,7 +69,7 @@ namespace SqlBulkTools
         /// </summary>
         /// <param name="columnName"></param>
         /// <returns></returns>
-        public QueryUpdateReady<T> SetIdentityColumn(Expression<Func<T, object>> columnName)
+        public QueryUpdateReady<T> SetIdentityColumn<TProp>(Expression<Func<T, TProp>> columnName)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
 

--- a/SqlBulkTools.NetStandard/QueryOperations/QueryUpsertReady.cs
+++ b/SqlBulkTools.NetStandard/QueryOperations/QueryUpsertReady.cs
@@ -61,7 +61,7 @@ namespace SqlBulkTools
         /// <param name="columnName"></param>
         /// <param name="outputIdentity"></param>
         /// <returns></returns>
-        public QueryUpsertReady<T> SetIdentityColumn(Expression<Func<T, object>> columnName, ColumnDirectionType outputIdentity)
+        public QueryUpsertReady<T> SetIdentityColumn<TProp>(Expression<Func<T, TProp>> columnName, ColumnDirectionType outputIdentity)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
             _outputIdentity = outputIdentity;
@@ -82,7 +82,7 @@ namespace SqlBulkTools
         /// </summary>
         /// <param name="columnName"></param>
         /// <returns></returns>
-        public QueryUpsertReady<T> ExcludeColumnFromUpdate(Expression<Func<T, object>> columnName)
+        public QueryUpsertReady<T> ExcludeColumnFromUpdate<TProp>(Expression<Func<T, TProp>> columnName)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
 
@@ -104,7 +104,7 @@ namespace SqlBulkTools
         /// </summary>
         /// <param name="columnName"></param>
         /// <returns></returns>
-        public QueryUpsertReady<T> SetIdentityColumn(Expression<Func<T, object>> columnName)
+        public QueryUpsertReady<T> SetIdentityColumn<TProp>(Expression<Func<T, TProp>> columnName)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
 
@@ -126,7 +126,7 @@ namespace SqlBulkTools
         /// </summary>
         /// <param name="columnName"></param>
         /// <returns></returns>
-        public QueryUpsertReady<T> MatchTargetOn(Expression<Func<T, object>> columnName)
+        public QueryUpsertReady<T> MatchTargetOn<TProp>(Expression<Func<T, TProp>> columnName)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
 
@@ -146,7 +146,7 @@ namespace SqlBulkTools
         /// <param name="columnName"></param>
         /// <param name="collation">Only explicitly set the collation if there is a collation conflict.</param>
         /// <returns></returns>
-        public QueryUpsertReady<T> MatchTargetOn(Expression<Func<T, object>> columnName, string collation)
+        public QueryUpsertReady<T> MatchTargetOn<TProp>(Expression<Func<T, TProp>> columnName, string collation)
         {
             var propertyName = BulkOperationsHelper.GetPropertyName(columnName);
 

--- a/SqlBulkTools.NetStandard/SqlBulkTools.NetStandard.csproj
+++ b/SqlBulkTools.NetStandard/SqlBulkTools.NetStandard.csproj
@@ -1,7 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+  <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>7.2</LangVersion>
+    <Company />
+    <Product />
+    <Version>1.0.0</Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DebugSymbols>true</DebugSymbols>
@@ -11,16 +17,6 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <Authors>tiagorosendo, zek99, gtaylor44</Authors>
-    <RepositoryUrl>https://github.com/tiagorosendo/SqlBulkTools</RepositoryUrl>
-    <PackageProjectUrl>https://github.com/tiagorosendo/SqlBulkTools</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/tiagorosendo/SqlBulkTools/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageTags>SQL BULK BULKINSERT BULKUPDATE</PackageTags>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-  </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>bin\Debug\netstandard2.0\SqlBulkTools.NetStandard.xml</DocumentationFile>

--- a/SqlBulkTools.sln
+++ b/SqlBulkTools.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2047
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31005.135
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SqlBulkTools.NetStandard", "SqlBulkTools.NetStandard\SqlBulkTools.NetStandard.csproj", "{CE4F978A-AE8A-4F7B-8A2D-3E5A4B00D18F}"
 EndProject
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.travis.yml = .travis.yml
 	EndProjectSection
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "SqlBulkTools.FSharp", "SqlBulkTools.FSharp\SqlBulkTools.FSharp.fsproj", "{30F6CAA3-4349-46C5-AAFE-E8B5F2C7F49E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -26,6 +28,10 @@ Global
 		{F1E1BFDA-3509-477F-8CF6-A8CA312D60E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F1E1BFDA-3509-477F-8CF6-A8CA312D60E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F1E1BFDA-3509-477F-8CF6-A8CA312D60E6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{30F6CAA3-4349-46C5-AAFE-E8B5F2C7F49E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{30F6CAA3-4349-46C5-AAFE-E8B5F2C7F49E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{30F6CAA3-4349-46C5-AAFE-E8B5F2C7F49E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{30F6CAA3-4349-46C5-AAFE-E8B5F2C7F49E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
# Changes
## Made the API "F# Friendly"
I made the codebase "F# friendly" by changing the Linq.Expression lambdas that are designed to obtain the property names to 
use a generic `TProp` argument instead of `object`.  F# does not implicitly cast to object, which means that the old way required a manual cast for each call to `AddColumn`. 

This is what I had to do in F# before the change:
```fsharp
    .AddColumn(fun s -> s.Id :> obj)     // manual cast to object at the end of each call
    .AddColumn(fun s -> s.ProjectId :> obj)
```

After the change, it is greatly simplified to this:
```fsharp
    .AddColumn(fun s -> s.Id)
    .AddColumn(fun s -> s.ProjectId)
```
NOTE: _The C# code stays the same either way._

## Bug Fix
I changed the `actualColumns` dictionary lookup in `BulkOperationsHelper.BuildCreateTempTable` to be case-insensitive because it was causing some of my lookups to fail to retrieve the actual database column type that was retrieved from the database schema.

